### PR TITLE
docs: fixes the readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package exports 3 different navigators:
 You can import individual navigators and use them:
 
 ```js
-import createMaterialBottomTabNavigator from 'react-navigation-tabs/createMaterialBottomTabNavigator';
+import { createMaterialBottomTabNavigator } from 'react-navigation-tabs';
 
 export default createMaterialBottomTabNavigator({
   Album: { screen: Album },


### PR DESCRIPTION
This pull request fixes the readme example to be consistent with the expo app examples. ```from 'react-navigation-tabs/createMaterialBottomTabNavigator'``` ends up not resolved for me.