### PR TITLE
Lazy initialized MaterialTopTabNavigator routes

### DIFF
--- a/src/navigators/createBottomTabNavigator.js
+++ b/src/navigators/createBottomTabNavigator.js
@@ -118,7 +118,7 @@ class TabNavigationView extends React.PureComponent<Props, State> {
                   StyleSheet.absoluteFill,
                   { opacity: isFocused ? 1 : 0 },
                 ]}
-                isFocused={isFocused}
+                isVisible={isFocused}
               >
                 {renderScene({ route })}
               </ResourceSavingScene>

--- a/src/navigators/createMaterialTopTabNavigator.js
+++ b/src/navigators/createMaterialTopTabNavigator.js
@@ -36,7 +36,7 @@ class MaterialTabView extends React.PureComponent<Props> {
       android: { width: 1, height: 0 },
     }),
     animationEnabled: true,
-    lazy: true,
+    lazy: false,
     optimizationsEnabled: false,
   };
 

--- a/src/utils/createTabNavigator.js
+++ b/src/utils/createTabNavigator.js
@@ -27,16 +27,8 @@ export type InjectedProps = {
   screenProps?: any,
 };
 
-type State = {
-  isSwiping: boolean,
-};
-
 export default function createTabNavigator(TabView: React.ComponentType<*>) {
   class NavigationView extends React.Component<*, State> {
-    state = {
-      isSwiping: false,
-    };
-
     _renderScene = ({ route }) => {
       const { screenProps, descriptors } = this.props;
       const descriptor = descriptors[route.key];
@@ -176,9 +168,6 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
           navigation={navigation}
           descriptors={descriptors}
           screenProps={screenProps}
-          onSwipeStart={this._handleSwipeStart}
-          onSwipeEnd={this._handleSwipeEnd}
-          isSwiping={this.state.isSwiping}
         />
       );
     }

--- a/src/utils/createTabNavigator.js
+++ b/src/utils/createTabNavigator.js
@@ -29,6 +29,10 @@ export type InjectedProps = {
 
 export default function createTabNavigator(TabView: React.ComponentType<*>) {
   class NavigationView extends React.Component<*> {
+    state = {
+      isSwiping: false,
+    };
+
     _renderScene = ({ route }) => {
       const { screenProps, descriptors } = this.props;
       const descriptor = descriptors[route.key];
@@ -132,6 +136,14 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
       this._jumpTo(this.props.navigation.state.routes[index].routeName);
     };
 
+    _handleSwipeStart = () => {
+      this.setState({ isSwiping: true });
+    };
+
+    _handleSwipeEnd = () => {
+      this.setState({ isSwiping: false });
+    };
+
     _jumpTo = routeName =>
       this.props.navigation.dispatch(NavigationActions.navigate({ routeName }));
 
@@ -160,6 +172,9 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
           navigation={navigation}
           descriptors={descriptors}
           screenProps={screenProps}
+          onSwipeStart={this._handleSwipeStart}
+          onSwipeEnd={this._handleSwipeEnd}
+          isSwiping={this.state.isSwiping}
         />
       );
     }

--- a/src/utils/createTabNavigator.js
+++ b/src/utils/createTabNavigator.js
@@ -27,8 +27,12 @@ export type InjectedProps = {
   screenProps?: any,
 };
 
+type State = {
+  isSwiping: boolean,
+};
+
 export default function createTabNavigator(TabView: React.ComponentType<*>) {
-  class NavigationView extends React.Component<*> {
+  class NavigationView extends React.Component<*, State> {
     state = {
       isSwiping: false,
     };

--- a/src/views/ResourceSavingScene.js
+++ b/src/views/ResourceSavingScene.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 
 type Props = {
-  isFocused: boolean,
+  isVisible: boolean,
   children: React.Node,
   style?: any,
 };
@@ -13,7 +13,7 @@ const FAR_FAR_AWAY = 3000; // this should be big enough to move the whole view o
 
 export default class ResourceSavingScene extends React.Component<Props> {
   render() {
-    const { isFocused, children, style, ...rest } = this.props;
+    const { isVisible, children, style, ...rest } = this.props;
 
     return (
       <View
@@ -22,12 +22,12 @@ export default class ResourceSavingScene extends React.Component<Props> {
         removeClippedSubviews={
           // On iOS, set removeClippedSubviews to true only when not focused
           // This is an workaround for a bug where the clipped view never re-appears
-          Platform.OS === 'ios' ? !isFocused : true
+          Platform.OS === 'ios' ? !isVisible : true
         }
-        pointerEvents={isFocused ? 'auto' : 'none'}
+        pointerEvents={isVisible ? 'auto' : 'none'}
         {...rest}
       >
-        <View style={isFocused ? styles.attached : styles.detached}>
+        <View style={isVisible ? styles.attached : styles.detached}>
           {children}
         </View>
       </View>


### PR DESCRIPTION
Routes in `MaterialTopTabNavigator` are now lazy initialized like in `MaterialBottomTabNavigator`.

A scene visibility is computed from multiple states and props:

To handle the pan between tabs, we check if you're currently swiping between tabs and the prop `lazyOnSwipe` is true (default value) or if the tab have been already loaded, we'll check if this tab is a sibling of the focused tab. Then, we'll display the tab if it's a sibling.

~With the prop `animationEnabled` to true, we shouldn't hide a tab before the transition is done. So we're waiting `COMPLETE_TRANSITION` action to hide it. Also, if the prop `sceneAlwaysVisible` is true (default value), we won't hide scenes between A and D while transitioning.~

If the current tab has not been loaded and must not be visible, we do not render it.

I'll update the docs accordingly to this PR.

![tabs-2](https://user-images.githubusercontent.com/7189823/38261082-3bd30d04-3737-11e8-854e-684430db771f.gif)

<!--
#### Default behavior 
Tabs are lazy initialized on swipe or focus and are always visible while transitioning.

![tabs-1](https://user-images.githubusercontent.com/7189823/38260989-060f5808-3737-11e8-87ed-d138fec6022b.gif)

#### Hide tabs between while transitioning

```js
{
  sceneAlwaysVisible: false,
}
```

![tabs-2](https://user-images.githubusercontent.com/7189823/38261082-3bd30d04-3737-11e8-854e-684430db771f.gif)

#### Fallback to only lazy initialized tabs on focus

```js
{
  lazyOnSwipe: false,
}
```

![tabs-3](https://user-images.githubusercontent.com/7189823/38261164-7bcc6018-3737-11e8-8758-de71d28218ae.gif)

-->