### PR TITLE
Fix tab action in for react nav v2

### DIFF
--- a/src/utils/createTabNavigator.js
+++ b/src/utils/createTabNavigator.js
@@ -6,6 +6,7 @@ import {
   StackActions,
   createNavigator,
   createNavigationContainer,
+  NavigationActions,
 } from 'react-navigation';
 import SceneView from 'react-navigation/src/views/SceneView';
 
@@ -95,7 +96,9 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
 
     _handleIndexChange = index => {
       const { navigation } = this.props;
-      navigation.navigate(navigation.state.routes[index].routeName);
+      navigation.dispatch(NavigationActions.navigate({
+        routeName: navigation.state.routes[index].routeName,
+      }));
     };
 
     render() {


### PR DESCRIPTION
The action helpers may not be available at the navigator level, they will be there inside the screen.

This change dispatches a normal explicit action, without relying on the helper. Alternatively we could use a child navigation prop on a screen descriptor, but this is easier right now.