### PR TITLE
Hook up tabBarOnPress

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prop-types": "^15.6.0",
     "react-lifecycles-compat": "^1.0.2",
     "react-native-safe-area-view": "^0.7.0",
-    "react-native-tab-view": "~0.0.77"
+    "react-native-tab-view": "~0.0.78"
   },
   "devDependencies": {
     "@expo/vector-icons": "^6.2.0",

--- a/src/navigators/createMaterialTopTabNavigator.js
+++ b/src/navigators/createMaterialTopTabNavigator.js
@@ -45,12 +45,38 @@ class TabView extends React.PureComponent<Props> {
     return route.routeName;
   };
 
-  _getOnPress = (previousScene, { route }) => {
+  _onTabPressNeeded() {
+    const { descriptors } = this.props;
+    for (let key in descriptors) {
+      const descriptor = descriptors[key];
+      const options = descriptor.options;
+      if (options.tabBarOnPress) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  _getOnPress() {
+    if (!this._onTabPressNeeded()) {
+      return null;
+    }
+    return this._onTabPress;
+  };
+
+  _onTabPress = ({ route, focused }) => {
     const { descriptors } = this.props;
     const descriptor = descriptors[route.key];
     const options = descriptor.options;
-
-    return options.tabBarOnPress;
+    if (!options.tabBarOnPress) {
+      return;
+    }
+    const { navigation } = descriptor;
+    const navigationStaticFocus = {
+      ...navigation,
+      isFocused: () => focused,
+    };
+    options.tabBarOnPress({ navigation: navigationStaticFocus });
   };
 
   _getTestIDProps = ({ route, focused }) => {
@@ -107,6 +133,7 @@ class TabView extends React.PureComponent<Props> {
         getLabelText={this.props.getLabelText}
         getTestIDProps={this._getTestIDProps}
         renderIcon={this._renderIcon}
+        onTabPress={this._getOnPress()}
       />
     );
   };

--- a/src/navigators/createMaterialTopTabNavigator.js
+++ b/src/navigators/createMaterialTopTabNavigator.js
@@ -45,40 +45,6 @@ class TabView extends React.PureComponent<Props> {
     return route.routeName;
   };
 
-  _onTabPressNeeded() {
-    const { descriptors } = this.props;
-    for (let key in descriptors) {
-      const descriptor = descriptors[key];
-      const options = descriptor.options;
-      if (options.tabBarOnPress) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  _getOnPress() {
-    if (!this._onTabPressNeeded()) {
-      return null;
-    }
-    return this._onTabPress;
-  };
-
-  _onTabPress = ({ route, focused }) => {
-    const { descriptors } = this.props;
-    const descriptor = descriptors[route.key];
-    const options = descriptor.options;
-    if (!options.tabBarOnPress) {
-      return;
-    }
-    const { navigation } = descriptor;
-    const navigationStaticFocus = {
-      ...navigation,
-      isFocused: () => focused,
-    };
-    options.tabBarOnPress({ navigation: navigationStaticFocus });
-  };
-
   _getTestIDProps = ({ route, focused }) => {
     const { descriptors } = this.props;
     const descriptor = descriptors[route.key];
@@ -133,7 +99,7 @@ class TabView extends React.PureComponent<Props> {
         getLabelText={this.props.getLabelText}
         getTestIDProps={this._getTestIDProps}
         renderIcon={this._renderIcon}
-        onTabPress={this._getOnPress()}
+        onTabPress={this.props.onTabPress}
       />
     );
   };

--- a/src/utils/createTabNavigator.js
+++ b/src/utils/createTabNavigator.js
@@ -70,27 +70,23 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
       return route.routeName;
     };
 
-    _handleOnTabPress = ({ route }) => {
+    _handleOnTabPress = ({ route, focused }) => {
       const { descriptors } = this.props;
       const descriptor = descriptors[route.key];
       const { navigation, options } = descriptor;
 
       if (options.tabBarOnPress) {
+        const navigationStaticFocus = {
+          ...navigation,
+          isFocused: () => focused,
+        };
         options.tabBarOnPress({
-          navigation,
+          navigation: navigationStaticFocus,
         });
-      } else {
-        const isFocused =
-          this.props.navigation.state.index ===
-          this.props.navigation.state.routes.indexOf(route);
-
-        if (isFocused) {
-          if (route.hasOwnProperty('index') && route.index > 0) {
-            navigation.dispatch(StackActions.popToTop({ key: route.key }));
-          } else {
-            // TODO: do something to scroll to top
-          }
-        }
+      } else if (focused && route.hasOwnProperty('index') && route.index > 0) {
+        navigation.dispatch(StackActions.popToTop({ key: route.key }));
+      } else if (focused) {
+        // TODO: do something to scroll to top
       }
     };
 

--- a/src/utils/createTabNavigator.js
+++ b/src/utils/createTabNavigator.js
@@ -74,9 +74,7 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
       const { descriptors } = this.props;
       const descriptor = descriptors[route.key];
       const { navigation, options } = descriptor;
-      const focused =
-        this.props.navigation.state.index ===
-        this.props.navigation.state.routes.indexOf(route);
+      const focused = navigation.isFocused();
 
       if (options.tabBarOnPress) {
         options.tabBarOnPress({ navigation });

--- a/src/utils/createTabNavigator.js
+++ b/src/utils/createTabNavigator.js
@@ -70,19 +70,16 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
       return route.routeName;
     };
 
-    _handleOnTabPress = ({ route, focused }) => {
+    _handleOnTabPress = ({ route }) => {
       const { descriptors } = this.props;
       const descriptor = descriptors[route.key];
       const { navigation, options } = descriptor;
+      const focused =
+        this.props.navigation.state.index ===
+        this.props.navigation.state.routes.indexOf(route);
 
       if (options.tabBarOnPress) {
-        const navigationStaticFocus = {
-          ...navigation,
-          isFocused: () => focused,
-        };
-        options.tabBarOnPress({
-          navigation: navigationStaticFocus,
-        });
+        options.tabBarOnPress({ navigation });
       } else if (focused && route.hasOwnProperty('index') && route.index > 0) {
         navigation.dispatch(StackActions.popToTop({ key: route.key }));
       } else if (focused) {

--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -201,8 +201,8 @@ class TabBarBottom extends React.Component<Props> {
             <TouchableWithoutFeedback
               key={route.key}
               onPress={() => {
-                jumpTo(route.key);
                 onTabPress({ route });
+                jumpTo(route.key);
               }}
             >
               <View


### PR DESCRIPTION
Right now `tabBarOnPress` is ignored. This PR hooks it up to `react-native-tab-view`'s `onTabPress`, and uses the new `react-navigation@2.0` parameter type (an object containing a single property, which is the `navigation` prop).