### PR TITLE
Add accessibilityLabel and testID to BottomTabBar

### DIFF
--- a/src/navigators/createBottomTabNavigator.js
+++ b/src/navigators/createBottomTabNavigator.js
@@ -49,6 +49,16 @@ class TabNavigationView extends React.PureComponent<Props, State> {
     return label;
   };
 
+  _getTestIDProps = ({ route, focused }) => {
+    const { descriptors } = this.props;
+    const descriptor = descriptors[route.key];
+    const options = descriptor.options;
+
+    return typeof options.tabBarTestIDProps === 'function'
+      ? options.tabBarTestIDProps({ focused })
+      : options.tabBarTestIDProps;
+  };
+
   _renderTabBar = () => {
     const {
       tabBarComponent: TabBarComponent = BottomTabBar,
@@ -78,6 +88,7 @@ class TabNavigationView extends React.PureComponent<Props, State> {
         screenProps={screenProps}
         onTabPress={onTabPress}
         getLabelText={getLabelText}
+        getTestIDProps={this._getTestIDProps}
         renderIcon={renderIcon}
       />
     );

--- a/src/navigators/createBottomTabNavigator.js
+++ b/src/navigators/createBottomTabNavigator.js
@@ -49,16 +49,6 @@ class TabNavigationView extends React.PureComponent<Props, State> {
     return label;
   };
 
-  _getTestIDProps = ({ route, focused }) => {
-    const { descriptors } = this.props;
-    const descriptor = descriptors[route.key];
-    const options = descriptor.options;
-
-    return typeof options.tabBarTestIDProps === 'function'
-      ? options.tabBarTestIDProps({ focused })
-      : options.tabBarTestIDProps;
-  };
-
   _renderTabBar = () => {
     const {
       tabBarComponent: TabBarComponent = BottomTabBar,
@@ -66,6 +56,8 @@ class TabNavigationView extends React.PureComponent<Props, State> {
       navigation,
       screenProps,
       getLabelText,
+      getAccessibilityLabelText,
+      getTestID,
       renderIcon,
       onTabPress,
     } = this.props;
@@ -88,7 +80,8 @@ class TabNavigationView extends React.PureComponent<Props, State> {
         screenProps={screenProps}
         onTabPress={onTabPress}
         getLabelText={getLabelText}
-        getTestIDProps={this._getTestIDProps}
+        getAccessibilityLabelText={getAccessibilityLabelText}
+        getTestID={getTestID}
         renderIcon={renderIcon}
       />
     );

--- a/src/navigators/createMaterialTopTabNavigator.js
+++ b/src/navigators/createMaterialTopTabNavigator.js
@@ -45,16 +45,6 @@ class TabView extends React.PureComponent<Props> {
     return route.routeName;
   };
 
-  _getTestIDProps = ({ route, focused }) => {
-    const { descriptors } = this.props;
-    const descriptor = descriptors[route.key];
-    const options = descriptor.options;
-
-    return typeof options.tabBarTestIDProps === 'function'
-      ? options.tabBarTestIDProps({ focused })
-      : options.tabBarTestIDProps;
-  };
-
   _renderIcon = ({ focused, route, tintColor }) => {
     const { descriptors } = this.props;
     const descriptor = descriptors[route.key];
@@ -97,7 +87,8 @@ class TabView extends React.PureComponent<Props> {
         screenProps={this.props.screenProps}
         navigation={this.props.navigation}
         getLabelText={this.props.getLabelText}
-        getTestIDProps={this._getTestIDProps}
+        getAccessibilityLabelText={this.props.getAccessibilityLabelText}
+        getTestID={this.props.getTestID}
         renderIcon={this._renderIcon}
         onTabPress={this.props.onTabPress}
       />

--- a/src/utils/createTabNavigator.js
+++ b/src/utils/createTabNavigator.js
@@ -12,6 +12,8 @@ import {
 
 export type InjectedProps = {
   getLabelText: (props: { route: any }) => any,
+  getAccessibilityLabelText: (route: any) => string,
+  getTestID: (route: any) => string,
   renderIcon: (props: {
     route: any,
     focused: boolean,
@@ -65,6 +67,30 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
 
       if (typeof options.title === 'string') {
         return options.title;
+      }
+
+      return route.routeName;
+    };
+
+    _getAccessibilityLabelText = route => {
+      const { descriptors } = this.props;
+      const descriptor = descriptors[route.key];
+      const options = descriptor.options;
+
+      if (options.tabBarAccessibilityLabel) {
+        return options.tabBarAccessibilityLabel;
+      }
+
+      return this._getLabelText({ route });
+    };
+
+    _getTestID = route => {
+      const { descriptors } = this.props;
+      const descriptor = descriptors[route.key];
+      const options = descriptor.options;
+
+      if (options.tabBarTestID) {
+        return options.tabBarTestID;
       }
 
       return route.routeName;
@@ -125,6 +151,8 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
         <TabView
           {...options}
           getLabelText={this._getLabelText}
+          getAccessibilityLabelText={this._getAccessibilityLabelText}
+          getTestID={this._getTestID}
           renderIcon={this._renderIcon}
           renderScene={this._renderScene}
           onIndexChange={this._handleIndexChange}

--- a/src/utils/createTabNavigator.js
+++ b/src/utils/createTabNavigator.js
@@ -12,8 +12,8 @@ import {
 
 export type InjectedProps = {
   getLabelText: (props: { route: any }) => any,
-  getAccessibilityLabelText: (route: any) => string,
-  getTestID: (route: any) => string,
+  getAccessibilityLabelText: (props: { route: any }) => string,
+  getTestID: (props: { route: any }) => string,
   renderIcon: (props: {
     route: any,
     focused: boolean,
@@ -72,28 +72,28 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
       return route.routeName;
     };
 
-    _getAccessibilityLabelText = route => {
+    _getAccessibilityLabelText = ({ route }) => {
       const { descriptors } = this.props;
       const descriptor = descriptors[route.key];
       const options = descriptor.options;
 
-      if (options.tabBarAccessibilityLabel) {
+      if (typeof options.tabBarAccessibility !== 'undefined') {
         return options.tabBarAccessibilityLabel;
       }
 
-      return this._getLabelText({ route });
+      const label = this._getLabelText({ route });
+
+      if (typeof label === 'string') {
+        return label;
+      }
     };
 
-    _getTestID = route => {
+    _getTestID = ({ route }) => {
       const { descriptors } = this.props;
       const descriptor = descriptors[route.key];
       const options = descriptor.options;
 
-      if (options.tabBarTestID) {
-        return options.tabBarTestID;
-      }
-
-      return route.routeName;
+      return options.tabBarTestID;
     };
 
     _handleTabPress = ({ route }) => {

--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -33,6 +33,8 @@ type Props = TabBarOptions & {
   jumpTo: any,
   onTabPress: any,
   getLabelText: ({ route: any }) => any,
+  getAccessibilityLabelText: (route: any) => string,
+  getTestID: (route: any) => string,
   renderIcon: any,
   dimensions: { width: number, height: number },
   isLandscape: boolean,
@@ -55,10 +57,6 @@ class TabBarBottom extends React.Component<Props> {
     showIcon: true,
     allowFontScaling: true,
     adaptive: isIOS11,
-  };
-
-  _renderTestIDProps = scene => {
-    return this.props.getTestIDProps && this.props.getTestIDProps(scene);
   };
 
   _renderLabel = ({ route, focused }) => {
@@ -197,8 +195,10 @@ class TabBarBottom extends React.Component<Props> {
         {routes.map((route, index) => {
           const focused = index === navigation.state.index;
           const scene = { route, focused };
-          const extraProps = this._renderTestIDProps(scene) || {};
-          const { testID, accessibilityLabel } = extraProps;
+          const accessibilityLabel = this.props.getAccessibilityLabelText(
+            route
+          );
+          const testID = this.props.getTestID(route);
 
           const backgroundColor = focused
             ? activeBackgroundColor

--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -36,6 +36,7 @@ type Props = TabBarOptions & {
   renderIcon: any,
   dimensions: { width: number, height: number },
   isLandscape: boolean,
+  getTestIDProps: ({ route: any }) => any,
 };
 
 const majorVersion = parseInt(Platform.Version, 10);
@@ -54,6 +55,10 @@ class TabBarBottom extends React.Component<Props> {
     showIcon: true,
     allowFontScaling: true,
     adaptive: isIOS11,
+  };
+
+  _renderTestIDProps = scene => {
+    return this.props.getTestIDProps && this.props.getTestIDProps(scene);
   };
 
   _renderLabel = ({ route, focused }) => {
@@ -192,6 +197,8 @@ class TabBarBottom extends React.Component<Props> {
         {routes.map((route, index) => {
           const focused = index === navigation.state.index;
           const scene = { route, focused };
+          const extraProps = this._renderTestIDProps(scene) || {};
+          const { testID, accessibilityLabel } = extraProps;
 
           const backgroundColor = focused
             ? activeBackgroundColor
@@ -204,6 +211,8 @@ class TabBarBottom extends React.Component<Props> {
                 onTabPress({ route });
                 jumpTo(route.key);
               }}
+              testID={testID}
+              accessibilityLabel={accessibilityLabel}
             >
               <View
                 style={[

--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -33,12 +33,11 @@ type Props = TabBarOptions & {
   jumpTo: any,
   onTabPress: any,
   getLabelText: ({ route: any }) => any,
-  getAccessibilityLabelText: (route: any) => string,
-  getTestID: (route: any) => string,
+  getAccessibilityLabelText: (props: { route: any }) => string,
+  getTestID: (props: { route: any }) => string,
   renderIcon: any,
   dimensions: { width: number, height: number },
   isLandscape: boolean,
-  getTestIDProps: ({ route: any }) => any,
 };
 
 const majorVersion = parseInt(Platform.Version, 10);
@@ -195,10 +194,10 @@ class TabBarBottom extends React.Component<Props> {
         {routes.map((route, index) => {
           const focused = index === navigation.state.index;
           const scene = { route, focused };
-          const accessibilityLabel = this.props.getAccessibilityLabelText(
-            route
-          );
-          const testID = this.props.getTestID(route);
+          const accessibilityLabel = this.props.getAccessibilityLabelText({
+            route,
+          });
+          const testID = this.props.getTestID({ route });
 
           const backgroundColor = focused
             ? activeBackgroundColor

--- a/src/views/MaterialTopTabBar.js
+++ b/src/views/MaterialTopTabBar.js
@@ -28,6 +28,8 @@ type Props = TabBarOptions & {
     tintColor: string,
   }) => React.Node,
   getLabelText: (props: { route: any }) => any,
+  getAccessibilityLabelText: (props: { route: any }) => string,
+  getTestID: (props: { route: any }) => string,
   useNativeDriver?: boolean,
   jumpTo: (key: string) => any,
 };


### PR DESCRIPTION
The accessibilityLabel and testID could be set for tab bar items in version 1.

I reused the implementation from 1.5.11. The navigationOptions can contain the accessibilityLabel and testID like this:

`tabBarTestIDProps: {
          accessibilityLabel: 'Label',
          testID: 'TestID',
        },`

### Motivation
Allow making apps accessible and allow for automated UI testing.

### Test plan
Create an app with a bottom tab bar. Add `tabBarTestIDProps` to the the navigation options of the tabs. Then run the app and use Accessibility Inspector for iOS and uiautomatorviewer to inspect the tabs.