### PR TITLE
Allows use of custom safe area inset

### DIFF
--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -39,6 +39,7 @@ type Props = TabBarOptions & {
   renderIcon: any,
   dimensions: { width: number, height: number },
   isLandscape: boolean,
+  safeAreaInset: { top: string, right: string, bottom: string, left: string },
 };
 
 const majorVersion = parseInt(Platform.Version, 10);
@@ -188,6 +189,7 @@ class TabBarBottom extends React.Component<Props> {
       activeBackgroundColor,
       inactiveBackgroundColor,
       onTabPress,
+      safeAreaInset,
       style,
       tabStyle,
     } = this.props;
@@ -205,7 +207,7 @@ class TabBarBottom extends React.Component<Props> {
     return (
       <SafeAreaView
         style={tabBarStyle}
-        forceInset={{ bottom: 'always', top: 'never' }}
+        forceInset={safeAreaInset || { bottom: 'always', top: 'never' }}
       >
         {routes.map((route, index) => {
           const focused = index === navigation.state.index;


### PR DESCRIPTION
### Motivation

We want to show content below the tab view, which behaved poorly on iPhone X because of the content safe area being added automatically. I added the ability to override this behaviour.

### Test plan

Create a BottomTabBar view and add content below it on iPhone X, then change the new `safeAreaInset` property.
