### PR TITLE
Use correct tab tint colors for iOS 11

### DIFF
--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -66,9 +66,9 @@ class TouchableWithoutFeedbackWrapper extends React.Component<*> {
 
 class TabBarBottom extends React.Component<Props> {
   static defaultProps = {
-    activeTintColor: '#3478f6', // Default active tint color in iOS 10
+    activeTintColor: isIOS11 ? '#007AFF': '#3478f6',
     activeBackgroundColor: 'transparent',
-    inactiveTintColor: '#929292', // Default inactive tint color in iOS 10
+    inactiveTintColor: isIOS11 ? '#8E8E93': '#929292',
     inactiveBackgroundColor: 'transparent',
     showLabel: true,
     showIcon: true,


### PR DESCRIPTION
### Motivation

The color of the system tab on iOS 11 and a React Navigation tab on my physical device are different. This fixes the issue by using the iOS 11 color on iOS 11 and the iOS 10 color on iOS10.

### Test plan
This change is trivial, only the color is changed.

### Source
iOS 11 Colors from Framer's iOS Design template
