### PR TITLE
Update createTabNavigator to pass swipeEnabled prop to MaterialTabView

### DIFF
--- a/src/utils/createTabNavigator.js
+++ b/src/utils/createTabNavigator.js
@@ -26,6 +26,7 @@ export type InjectedProps = {
   navigation: any,
   descriptors: any,
   screenProps?: any,
+  swipeEnabled?: boolean,
 };
 
 export default function createTabNavigator(TabView: React.ComponentType<*>) {
@@ -151,7 +152,7 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
     _isTabPress: boolean = false;
 
     render() {
-      const { descriptors, navigation, screenProps } = this.props;
+      const { descriptors, navigation, screenProps, swipeEnabled } = this.props;
       const { state } = navigation;
       const route = state.routes[state.index];
       const descriptor = descriptors[route.key];
@@ -174,6 +175,7 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
           navigation={navigation}
           descriptors={descriptors}
           screenProps={screenProps}
+          swipeEnabled={swipeEnabled}
         />
       );
     }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Within my app I would like the ability to disable swiping based on state. E.g if a user is on a screen and enabled a delete functionality on a list, UX dictates that the user shouldn't be able to swipe away from the screen until delete mode is cancelled. 

It seems as though createMaterialTopTabNavigator can use the swipeEnabled option within the render function and check it via props or options. Although I could not see a place where swipeEnabled could be passed as a prop based on state without having to reinitialise the whole tab navigator.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
createMaterialTopTabNavigator should continue to work as expected, you should be able to set the swipeEnabled via the options when setting up the tab navigator. But once initialised, you should be able to pass a swipeEnabled prop into the tabNavigator based on state change e.g.

```
const TabNavigator = createMaterialTopTabNavigator(
  {
    MainTab: {
      screen: MyHomeScreen,
      navigationOptions: {
        title: 'Welcome',
      },
    },
    SettingsTab: {
      screen: MySettingsScreen,
      navigationOptions: {
        title: 'Settings',
      },
    },
  },
  {
    tabBarComponent: MaterialTopTabBarWithStatusBar,
    tabBarOptions: {
      tabStyle: styles.tab,
    },
  }
);

class AppView extends React.Component {
  render() {
    return (
      <TabNavigator
        swipeEnabled={this.state.swipeEnabled}
      />
    );
  }
}
```


<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
