### PR TITLE
Upgrade react-native-safe-area-view

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "hoist-non-react-statics": "^2.5.0",
     "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.4",
-    "react-native-safe-area-view": "^0.9.0",
     "react-native-tab-view": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "hoist-non-react-statics": "^2.5.0",
     "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.4",
-    "react-native-safe-area-view": "^0.7.0",
+    "react-native-safe-area-view": "^0.9.0",
     "react-native-tab-view": "^1.0.0"
   },
   "devDependencies": {

--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -8,7 +8,7 @@ import {
   View,
   Platform,
 } from 'react-native';
-import SafeAreaView from 'react-native-safe-area-view';
+import { SafeAreaView } from 'react-navigation';
 
 import CrossFadeIcon from './CrossFadeIcon';
 import withDimensions from '../utils/withDimensions';
@@ -206,10 +206,7 @@ class TabBarBottom extends React.Component<Props> {
     ];
 
     return (
-      <SafeAreaView
-        style={tabBarStyle}
-        forceInset={safeAreaInset}
-      >
+      <SafeAreaView style={tabBarStyle} forceInset={safeAreaInset}>
         {routes.map((route, index) => {
           const focused = index === navigation.state.index;
           const scene = { route, focused };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4884,6 +4884,12 @@ react-native-safe-area-view@^0.8.0:
   dependencies:
     hoist-non-react-statics "^2.3.1"
 
+react-native-safe-area-view@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.9.0.tgz#10ece2ecac70e7005a5b0b3f06c8833060e6d21f"
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+
 react-native-tab-view@^0.0.77:
   version "0.0.77"
   resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.77.tgz#11ceb8e7c23100d07e628dc151b57797524d00d4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4884,12 +4884,6 @@ react-native-safe-area-view@^0.8.0:
   dependencies:
     hoist-non-react-statics "^2.3.1"
 
-react-native-safe-area-view@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.9.0.tgz#10ece2ecac70e7005a5b0b3f06c8833060e6d21f"
-  dependencies:
-    hoist-non-react-statics "^2.3.1"
-
 react-native-tab-view@^0.0.77:
   version "0.0.77"
   resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.77.tgz#11ceb8e7c23100d07e628dc151b57797524d00d4"


### PR DESCRIPTION
Upgrades `react-native-safe-area-view` to make a warning go away (`Cannot call setState() while not mounted...`)