### PR TITLE
Fix bottom tab bar icon layout on ipad

### DIFF
--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -151,7 +151,10 @@ class TabBarBottom extends React.Component<Props> {
         style={[
           styles.iconWithExplicitHeight,
           showLabel === false && !horizontal && styles.iconWithoutLabel,
-          showLabel !== false && !horizontal && styles.iconWithLabel,
+          showLabel !== false && (horizontal
+            ? styles.horizontalIconWithLabel
+            : styles.iconWithLabel
+          ),
         ]}
       />
     );
@@ -281,6 +284,10 @@ const styles = StyleSheet.create({
   },
   iconWithLabel: {
     flex: 1,
+  },
+  horizontalIconWithLabel: {
+    width: COMPACT_HEIGHT,
+    marginRight: 4,
   },
   iconWithExplicitHeight: {
     height: Platform.isPad ? DEFAULT_HEIGHT : COMPACT_HEIGHT,


### PR DESCRIPTION
Add style for horizontal Icon with label.

### Motivation

Without fix this container not have width and can't properly layout inner icon.

### Test plan

Check icon layout on tablets when label is not empty.
