### PR TITLE
Export all npm files, and source for react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,7 @@
   "version": "0.7.0",
   "description": "Tab Navigation components for React Navigation",
   "main": "dist/index.js",
-  "files": [
-    "dist/",
-    "createBottomTabNavigator.js",
-    "createMaterialTopTabNavigator.js"
-  ],
+  "react-native": "src/index.js",
   "scripts": {
     "test": "jest",
     "flow": "flow",


### PR DESCRIPTION
This allows all files to come with the npm package, and points Metro to the source code so that it can provide source maps for consumption in react-native apps.
