### PR TITLE
Add the ability to add your own custom onIndexChange callback

### DIFF
--- a/src/utils/createTabNavigator.js
+++ b/src/utils/createTabNavigator.js
@@ -143,6 +143,11 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
     };
 
     _handleIndexChange = index => {
+      const { onIndexChange } = this.props.navigationConfig;
+      if (onIndexChange) {
+        setTimeout(onIndexChange.bind(this, index));
+      }
+
       if (this._isTabPress) {
         this._isTabPress = false;
         return;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

`react-native-tab-views` has the ability to have an `onIndexChange` callback. But right now this library is stopping you from using it because it has its own `onIndexChange` method. I think it would be good to expose this API to the users to that users can add an `onIndexChange` to the `createMaterialTopTabNavigator`.

The main reason to have this is to be able to easily react to navigation changes within the created navigator. This is useful for example tracking user behaviour. I made sure it triggers after the navigation so that the state of the navigation would add up to the index that is being send in to the `onIndexChange` callback.

The same result is hard to reach in a different way. There is `onSwipeStart`, `onSwipeEnd` and `tabBarOnPress` but those will also be triggered when the location is not changed by the swipe or press, and _before_ the navigation actually finished.

### Test plan

It would look something like this:
```js
createMaterialTopTabNavigator({
  ... // other config
  onIndexChange () {
    // This will be triggered _after_ the index has changed and navigation is up to date
  },
});
```

I'm not sure if this is the best way to do it, but I wanted to open a PR to discuss this suggestion anyway.