### PR TITLE
Distribute source

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "main": "dist/index.js",
   "files": [
     "dist/",
+    "src/",
     "createBottomTabNavigator.js",
     "createMaterialTopTabNavigator.js"
   ],
+  "react-native": "src/index.js",
   "scripts": {
     "test": "jest",
     "flow": "flow",


### PR DESCRIPTION
By shipping source files and setting the ‘react-native’ entry point to src, the RN packager can parse the module and provide source maps when debugging from your app. This makes the install slightly heavier but is worth it for the improved ergonomics.