### PR TITLE
Fix renderPager undefined override

### DIFF
--- a/src/navigators/createMaterialTopTabNavigator.js
+++ b/src/navigators/createMaterialTopTabNavigator.js
@@ -17,6 +17,7 @@ type Props = InjectedProps & {
   lazy?: boolean,
   optimizationsEnabled?: boolean,
   swipeEnabled?: boolean,
+  renderPager?: (props: *) => React.Node,
   tabBarComponent?: React.ComponentType<*>,
   tabBarOptions?: TabBarOptions,
   tabBarPosition?: 'top' | 'bottom',
@@ -222,7 +223,7 @@ class MaterialTabView extends React.PureComponent<Props, State> {
       ...rest
     } = this.props;
 
-    let renderPager;
+    let renderPager = rest.renderPager;
 
     const { state } = this.props.navigation;
     const route = state.routes[state.index];


### PR DESCRIPTION
### Motivation

[react-native-tab-view](https://github.com/react-native-community/react-native-tab-view) provides some pager alternatives like `PagerExperimental` but we can't use it with `react-navigation-tabs` because it always overrides `renderPager` prop with `undefined`.

### Test plan

When `useNativeDriver={true}`, built-in `MaterialTopTabBar` not working because `color` style prop not supported by native animation.

```js
createMaterialTopTabNavigator({
  ...
}, {
  tabBarComponent: CustomTabBarComponent,
  renderPager: props => <PagerExperimental {...props} {GestureHandler} userNativeDriver={true} />
})
```