### PR TITLE
added customScroll functionality, and proposed changes to bottom-tab-navigator docs

### DIFF
--- a/bottom-tab-navigator.md
+++ b/bottom-tab-navigator.md
@@ -1,0 +1,116 @@
+---
+id: bottom-tab-navigator
+title: createBottomTabNavigator
+sidebar_label: createBottomTabNavigator
+---
+
+A simple tab bar on the bottom of the screen that lets you switch between different routes. Routes are lazily initialized -- their screen components are not mounted until they are first focused.
+
+> For a complete usage guide please visit [Tab Navigation](https://reactnavigation.org/docs/en/tab-based-navigation.html)
+
+```js
+createBottomTabNavigator(RouteConfigs, BottomTabNavigatorConfig);
+```
+
+## RouteConfigs
+
+
+The route configs object is a mapping from route name to a route config, which tells the navigator what to present for that route, see [example](stack-navigator.html#routeconfigs) from stack navigator.
+
+## BottomTabNavigatorConfig
+
+* `initialRouteName` - The routeName for the initial tab route when first loading.
+* `order` - Array of routeNames which defines the order of the tabs.
+* `paths` - Provide a mapping of routeName to path config, which overrides the paths set in the routeConfigs.
+* `backBehavior` - Should the back button cause a tab switch to the initial tab? If yes, set to `initialRoute`, otherwise `none`. Defaults to `initialRoute` behavior.
+* `tabBarComponent` - Optional, override component to use as the tab bar.
+* `tabBarOptions` - An object with the following properties:
+  * `activeTintColor` - Label and icon color of the active tab.
+  * `activeBackgroundColor` - Background color of the active tab.
+  * `inactiveTintColor` - Label and icon color of the inactive tab.
+  * `inactiveBackgroundColor` - Background color of the inactive tab.
+  * `showLabel` - Whether to show label for tab, default is true.
+  * `showIcon` - Whether to show icon for tab, default is true.
+  * `style` - Style object for the tab bar.
+  * `labelStyle` - Style object for the tab label.
+  * `tabStyle` - Style object for the tab.
+  * `allowFontScaling` - Whether label font should scale to respect Text Size accessibility settings, default is true.
+  * `safeAreaInset` - Override the `forceInset` prop for `<SafeAreaView>`. Defaults to `{ bottom: 'always', top: 'never' }`. Available keys are `top | bottom | left | right` provided with the values `'always' | 'never'`.
+
+Example:
+
+```js
+tabBarOptions: {
+  activeTintColor: '#e91e63',
+  labelStyle: {
+    fontSize: 12,
+  },
+  style: {
+    backgroundColor: 'blue',
+  },
+}
+```
+
+If you want to customize the `tabBarComponent`:
+
+```js
+import { createBottomTabNavigator, BottomTabBar } from 'react-navigation-tabs';
+
+const TabBarComponent = (props) => (<BottomTabBar {...props} />);
+
+const TabScreens = createBottomTabNavigator(
+  {
+    tabBarComponent: props =>
+      <TabBarComponent
+        {...props}
+        style={{ borderTopColor: '#605F60' }}
+      />,
+  },
+);
+```
+
+
+## `navigationOptions` for screens inside of the navigator
+
+#### `title`
+
+Generic title that can be used as a fallback for `headerTitle` and `tabBarLabel`.
+
+#### `tabBarVisible`
+
+`true` or `false` to show or hide the tab bar, if not set then defaults to `true`.
+
+#### `tabBarIcon`
+
+React Element or a function that given `{ focused: boolean, horizontal: boolean, tintColor: string }` returns a React.Node, to display in the tab bar. `horizontal` is `true` when the device is in landscape and `false` when portrait. The icon is re-rendered whenever the device orientation changes.
+
+#### `tabBarLabel`
+
+Title string of a tab displayed in the tab bar or React Element or a function that given `{ focused: boolean, tintColor: string }` returns a React.Node, to display in tab bar. When undefined, scene `title` is used. To hide, see `tabBarOptions.showLabel` in the previous section.
+
+#### `tabBarButtonComponent`
+
+React Component that wraps the icon and label and implements `onPress`. The default is a wrapper around `TouchableWithoutFeedback` that makes it behave the same as other touchables. `tabBarButtonComponent: TouchableOpacity` would use `TouchableOpacity` instead.
+
+#### `tabBarAccessibilityLabel`
+
+Accessibility label for the tab button. This is read by the screen reader when the user taps the tab. It's recommended to set this if you don't have a label for the tab.
+
+#### `tabBarTestID`
+
+ID to locate this tab button in tests.
+
+#### `tabBarOnPress`
+
+Callback to handle press events; the argument is an object containing:
+
+* `navigation`: navigation prop for the screen
+* `defaultHandler`: the default handler for tab press. defaultHandler can be passed a custom scroll handler with parameters `customScroll` and `overridesDefaultScroll` (if you don't use react-navigations exported ScrollView/Lists, overridesDefaultScroll has no effect):
+    ``` 
+    function customTabBarOnPress({ navigation, defaultHandler }){
+        const { state: { routes, index } } = navigation, { params } = routes[index]
+        defaultHandler({ customScroll: params.customScrollHandler, overridesDefaultScroll: true })
+    } 
+    ```
+
+Useful for adding a custom logic before the transition to the next scene (the tapped one) starts.

--- a/src/utils/createTabNavigator.js
+++ b/src/utils/createTabNavigator.js
@@ -118,14 +118,15 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
       return options.tabBarTestID;
     };
 
-    _makeDefaultHandler = ({ route, navigation }) => ({ customScroll, overridesDefaultScroll }) => {
+    _makeDefaultHandler = ({ route, navigation }) => (custom = { }) => {
       if (navigation.isFocused()) {
         if (route.hasOwnProperty('index') && route.index > 0) {
           // If current tab has a nested navigator, pop to top
           navigation.dispatch(StackActions.popToTop({ key: route.key }));
         } else {
+          const { customScroll, overridesDefaultScroll } = custom
           if (customScroll && typeof customScroll === 'function') customScroll()
-          if (overridesDefaultScroll === false || typeof customScroll !== 'function') navigation.emit('refocus')
+          if (!overridesDefaultScroll || typeof customScroll !== 'function') navigation.emit('refocus')
         }
       } else {
         this._jumpTo(route.routeName);

--- a/src/utils/createTabNavigator.js
+++ b/src/utils/createTabNavigator.js
@@ -118,13 +118,14 @@ export default function createTabNavigator(TabView: React.ComponentType<*>) {
       return options.tabBarTestID;
     };
 
-    _makeDefaultHandler = ({ route, navigation }) => () => {
+    _makeDefaultHandler = ({ route, navigation }) => ({ customScroll, overridesDefaultScroll }) => {
       if (navigation.isFocused()) {
         if (route.hasOwnProperty('index') && route.index > 0) {
           // If current tab has a nested navigator, pop to top
           navigation.dispatch(StackActions.popToTop({ key: route.key }));
         } else {
-          navigation.emit('refocus');
+          if (customScroll && typeof customScroll === 'function') customScroll()
+          if (overridesDefaultScroll === false || typeof customScroll !== 'function') navigation.emit('refocus')
         }
       } else {
         this._jumpTo(route.routeName);


### PR DESCRIPTION
### Motivation

As it stands, if there is a list on the tab you are currently focused on, and you tap the focused tab icon, it will scroll to the top of the list. However, if there is an offset on the list, or if the screen has multiple lists, you cannot use the defaultHandler at all. 

Passing custom scroll handlers enables us to scroll however we wish without having to recreate the functionality of deciding whether to navigate to a different tab, pop to top, or scroll.

### Test plan

Call a function for tabBarOnPress: 
```
export default createBottomTabNavigator({
    Home: {
        screen: Home,
        navigationOptions: ({ navigation }) => ({
            tabBarOnPress: customTabBarOnPress,
        })
    },
})

/* the way I implemented it was to call navigation.setParams with the custom scroll 
function within the screen component */

function customTabBarOnPress({ navigation, defaultHandler }) {
    const { state: { routes, index } } = navigation, { params } = routes[index]
    const customScrollHandler = () => params != null ? params.customScroll() : null
    defaultHandler()
    defaultHandler({ customScroll: customScrollHandler, overridesDefaultScroll: true })
    /* default handler works the same as before, and the new handler works even if the 
    function passed is null as it only calls it if its type is a function */
}
```

## Doc changes

Current docs: https://reactnavigation.org/docs/en/bottom-tab-navigator.html#tabbaronpress

Callback to handle press events; the argument is an object containing:

* `navigation`: navigation prop for the screen
* `defaultHandler`: the default handler for tab press.

-> 

Callback to handle press events; the argument is an object containing:

* `navigation`: navigation prop for the screen
* `defaultHandler`: the default handler for tab press. defaultHandler can be passed a custom scroll function with parameters `customScroll` and `overridesDefaultScroll` (if you don't use react-navigation's exported ScrollView/Lists, overridesDefaultScroll has no effect):
    ``` 
    function customTabBarOnPress({ navigation, defaultHandler }){
        const { state: { routes, index } } = navigation, { params } = routes[index]
        defaultHandler({ customScroll: params.customScrollHandler, overridesDefaultScroll: true })
    } 
    ```