### PR TITLE
Fix the top margin of notch displays in iPhone X

### DIFF
--- a/src/navigators/createBottomTabNavigator.js
+++ b/src/navigators/createBottomTabNavigator.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import * as React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, SafeAreaView } from 'react-native';
 import { polyfill } from 'react-lifecycles-compat';
 
 // eslint-disable-next-line import/no-unresolved
@@ -69,19 +69,21 @@ class TabNavigationView extends React.PureComponent<Props, State> {
     }
 
     return (
-      <TabBarComponent
-        {...tabBarOptions}
-        jumpTo={this._jumpTo}
-        navigation={navigation}
-        screenProps={screenProps}
-        onTabPress={onTabPress}
-        onTabLongPress={onTabLongPress}
-        getLabelText={getLabelText}
-        getButtonComponent={getButtonComponent}
-        getAccessibilityLabel={getAccessibilityLabel}
-        getTestID={getTestID}
-        renderIcon={renderIcon}
-      />
+      <SafeAreaView>
+        <TabBarComponent
+          {...tabBarOptions}
+          jumpTo={this._jumpTo}
+          navigation={navigation}
+          screenProps={screenProps}
+          onTabPress={onTabPress}
+          onTabLongPress={onTabLongPress}
+          getLabelText={getLabelText}
+          getButtonComponent={getButtonComponent}
+          getAccessibilityLabel={getAccessibilityLabel}
+          getTestID={getTestID}
+          renderIcon={renderIcon}
+        />
+      </SafeAreaView>
     );
   };
 


### PR DESCRIPTION
In iPhone X the top tab bar is positioned under "notch" so that the tabs are not visible. This commit wraps `TabBarComponent` in `SafeAreaView` to add enough space below notch.
Current behavior:

<img width="512" alt="screen shot 2019-01-28 at 3 51 09 pm" src="https://user-images.githubusercontent.com/3218684/51836113-a2d99f80-2314-11e9-8c2d-ec97807fe213.png">

Intended behavior:

<img width="512" alt="screen shot 2019-01-28 at 3 52 40 pm" src="https://user-images.githubusercontent.com/3218684/51836163-cc92c680-2314-11e9-8e26-9db3b2d6ef96.png">