### PR TITLE
Added ability to customize the lazy component rendered by MaterialTopTabNavigator

### DIFF
--- a/src/navigators/createMaterialTopTabNavigator.js
+++ b/src/navigators/createMaterialTopTabNavigator.js
@@ -15,6 +15,7 @@ import ResourceSavingScene from '../views/ResourceSavingScene';
 type Props = InjectedProps & {
   animationEnabled?: boolean,
   lazy?: boolean,
+  renderLazyComponent?: () => JSX.Element,
   optimizationsEnabled?: boolean,
   swipeEnabled?: boolean,
   renderPager?: (props: *) => React.Node,
@@ -197,7 +198,7 @@ class MaterialTabView extends React.PureComponent<Props, State> {
       });
 
       if (!loaded.includes(index) && !mustBeVisible) {
-        return <View />;
+        return this.props.renderLazyComponent ? this.props.renderLazyComponent() : <View />;
       }
 
       if (optimizationsEnabled) {

--- a/src/navigators/createMaterialTopTabNavigator.js
+++ b/src/navigators/createMaterialTopTabNavigator.js
@@ -15,7 +15,7 @@ import ResourceSavingScene from '../views/ResourceSavingScene';
 type Props = InjectedProps & {
   animationEnabled?: boolean,
   lazy?: boolean,
-  renderLazyComponent?: () => JSX.Element,
+  renderLazyPlaceholder?: (routeName?: string) => React.Node,
   optimizationsEnabled?: boolean,
   swipeEnabled?: boolean,
   renderPager?: (props: *) => React.Node,
@@ -40,6 +40,7 @@ class MaterialTabView extends React.PureComponent<Props, State> {
     animationEnabled: true,
     lazy: false,
     optimizationsEnabled: false,
+    renderLazyPlaceholder: () => <View />
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -198,7 +199,7 @@ class MaterialTabView extends React.PureComponent<Props, State> {
       });
 
       if (!loaded.includes(index) && !mustBeVisible) {
-        return this.props.renderLazyComponent ? this.props.renderLazyComponent() : <View />;
+        return this.props.renderLazyPlaceholder(route.routeName);
       }
 
       if (optimizationsEnabled) {


### PR DESCRIPTION
# Motivation
As a developer, I want to be able to specify the lazy component used by a Material Top Tab Navigator. Since React Native is async in nature, it's possible to pan over and see the lazy component before the actual content is loaded. By default, the component is a View with no style. On slower devices, this can lead to a jarring transition.

# Solution
Add ability to pass a function which will render the lazy component. I am using this currently via https://www.npmjs.com/package/patch-package to render a View with the same background color as my content.

# Testing
- [x] Passing renderLazyComponent correctly renders the component before it is loaded - verified by panning on an iPhone 6S Plus
- [x] Omitting the property still renders a style-less View

# Example Usage

```
renderLazyComponent: () => (
    <View style={{ backgroundColor: MainColors.screenBackground, flex: 1 }} />
  )