### PR TITLE
fix hit slop for bottom tab bar

### DIFF
--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -64,7 +64,7 @@ class TouchableWithoutFeedbackWrapper extends React.Component<*> {
         onPress={onPress}
         onLongPress={onLongPress}
         testID={testID}
-        hitSlop={{ left: 15, right: 15, top: 5, bottom: 5 }}
+        hitSlop={{ left: 15, right: 15, top: 0, bottom: 5 }}
         accessibilityLabel={accessibilityLabel}
       >
         <View {...props} />


### PR DESCRIPTION
The problem this fixes is that if you currently tap just slightly above the tab bar, the button in the tab bar is going to respond to the tap - and it should not.

Two reasons for this change:

1) it breaks detox e2e test in the case when there is a tab navigator, and the screen in it has a scrollview that we're trying to scroll down (` await element(by.id('someScrollView')).scrollTo('bottom');`)

The reason this doesn't work is that when detox tries to tap and drag the scrollView, detox taps just above the tab bar - within the reach of the hitslop - and instead of the scrollview responding, the scroll ends up being ignored.

2) if you take a look at a native app such as files, you'll see that taps outside the bounds of the tab bar are ignored. It should be the same for the tabs in react-navigation
