### PR TITLE
fix: increase padding for iOS horizontal label alignment

### DIFF
--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -461,7 +461,7 @@ const styles = StyleSheet.create({
   },
   labelBeside: {
     fontSize: 12,
-    marginLeft: 25,
+    marginLeft: 20,
   },
 });
 

--- a/src/views/BottomTabBar.js
+++ b/src/views/BottomTabBar.js
@@ -461,7 +461,7 @@ const styles = StyleSheet.create({
   },
   labelBeside: {
     fontSize: 12,
-    marginLeft: 15,
+    marginLeft: 25,
   },
 });
 


### PR DESCRIPTION
Fixes #113 (increase padding for labels beside when emulating iOS horizontal label alignment).