### PR TITLE
fix: don't update navigation state when material navigator isn't focused

### DIFF
--- a/src/navigators/createMaterialTopTabNavigator.js
+++ b/src/navigators/createMaterialTopTabNavigator.js
@@ -33,7 +33,51 @@ type Props = {|
   style?: ViewStyleProp,
 |};
 
-class MaterialTabView extends React.PureComponent<Props> {
+type State = {|
+  index: number,
+|};
+
+class MaterialTabView extends React.PureComponent<Props, State> {
+  state = {
+    index: this.props.navigation.state.index,
+  };
+
+  componentDidMount() {
+    this.props.navigation.addListener('didFocus', this._handleFocus);
+  }
+
+  componentWillUnmount() {
+    this.props.navigation.removeListener('didFocus', this._handleFocus);
+  }
+
+  // The index change event fires after swipe animation
+  // If you quickly navigate to a new screen in stack before animation finishes,
+  // the index change event will fire after the previous navigation event
+  // By this time, the tab navigator is not focused anymore
+  // React Navigation fails to handle the action properly if the navigator is not focused
+  // So we keep the index in local state and synchronise when the navigator comes to focus
+  // It's pretty hacky, but there doesn't seem to be a better way :(
+  _handleFocus = () => {
+    const { navigation, onIndexChange } = this.props;
+    const { index } = this.state;
+
+    if (navigation.state.index !== index) {
+      // Synchornize the index on focus if it's not in sync
+      onIndexChange(index);
+    }
+  };
+
+  _handleIndexChange = index => {
+    const { navigation, onIndexChange } = this.props;
+
+    if (navigation.isFocused()) {
+      // Only synchornize the index when we're focused
+      onIndexChange(index);
+    }
+
+    this.setState({ index });
+  };
+
   _renderLazyPlaceholder = props => {
     const { lazyPlaceholderComponent: LazyPlaceholder } = this.props;
 
@@ -126,7 +170,11 @@ class MaterialTabView extends React.PureComponent<Props> {
     return (
       <TabView
         {...rest}
-        navigationState={navigation.state}
+        navigationState={{
+          routes: navigation.state.routes,
+          index: this.state.index,
+        }}
+        onIndexChange={this._handleIndexChange}
         swipeEnabled={swipeEnabled}
         renderTabBar={this._renderTabBar}
         renderLazyPlaceholder={this._renderLazyPlaceholder}


### PR DESCRIPTION
The index change event fires after swipe animation. If you quickly navigate to a new screen in stack before animation finishes, the index change event will fire after the previous navigation event. By this time, the tab navigator is not focused anymore. React Navigation fails to handle the action properly if the navigator is not focused. So we keep the index in local state and synchronize when the navigator comes to focus.

It's pretty hacky, but there doesn't seem to be a better way :(